### PR TITLE
Fix #29: Link hover effect for San Mateo Event Center

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -17,7 +17,7 @@ body {
   overflow-x: hidden;
 }
 
-*:hover {
+*:hover, *:visited, *:active, *:focus {
   text-decoration: none !important;
 }
 
@@ -372,12 +372,28 @@ body {
 }
 
 a.san-mateo{
-  color:white;
-
-}
-a.san-mateo:hover{
   color: white;
-  text-decoration: underline;
+
+  -webkit-transform:scale(1);
+  /* Browser Variations: */
+  -moz-transform:scale(1);
+  -o-transform:scale(1);
+  -webkit-transition-duration: 0.5s;
+  -moz-transition-duration: 0.5s;
+  -o-transition-duration: 0.5s;
+}
+
+a.san-mateo:hover{
+  display: inline-block;
+  color: white;
+
+  /* Browser Variations: */
+  -webkit-transform:scale(1.1);
+  -moz-transform:scale(1.1);
+  -o-transform:scale(1.1);
+  -webkit-transition-duration: 0.5s;
+  -moz-transition-duration: 0.5s;
+  -o-transition-duration: 0.5s;
 }
 
 /* Header-Buttons */

--- a/public/index.html
+++ b/public/index.html
@@ -47,7 +47,7 @@
           <div id="shading">
             <div class="main-title">
               <h1 class="main-txt">World's <span class="bold">Largest</span><br>Education Hackathon</h1>
-              <a href="https://www.google.com/maps/place/San+Mateo+County+Event+Center" class="san-mateo"><p class="sub-text">San Mateo Event Center</p></a>
+              <p class="sub-text"><a href="https://www.google.com/maps/place/San+Mateo+County+Event+Center" class="san-mateo">San Mateo Event Center</a></p>
               <p class="sub-text">October 23-25</p>
               <a href="https://hackingedu.typeform.com/to/ynFajD" data-mode="2" target="_blank"><button class="butt substatement">Apply Now</button></a>
               <a href="https://hackingedu.typeform.com/to/BEXo5M" data-mode="2" target="_blank"><button class="butt substatement">Sponsor Us</button> </a>


### PR DESCRIPTION
Text zooms, and reorganized HTML hierarchy to be consistent with the other `sub-text` element.
